### PR TITLE
Deprecate git protocol

### DIFF
--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -590,11 +590,13 @@ public class PluginCompatTester {
         ScmRepository repository;
         ScmManager scmManager = SCMManagerFactory.getInstance().createScmManager();
         for (String connectionURL: connectionURLs){
-            System.out.println("Checking out from SCM connection URL : " + connectionURL + " (" + name + "-" + version + ") at tag " + scmTag);
+            // scm:git:git:// is being deprecated (https://github.blog/2021-09-01-improving-git-protocol-security-github/)
+            String httpsConnectionURL = connectionURL != null ? connectionURL.replace("scm:git:git://", "scm:git:https://") : null;
+            System.out.println("Checking out from SCM connection URL : " + httpsConnectionURL + " (" + name + "-" + version + ") at tag " + scmTag);
             if (checkoutDirectory.isDirectory()) {
                 FileUtils.deleteDirectory(checkoutDirectory);
             }
-            repository = scmManager.makeScmRepository(connectionURL);
+            repository = scmManager.makeScmRepository(httpsConnectionURL);
             CheckOutScmResult result = scmManager.checkOut(repository, new ScmFileSet(checkoutDirectory), new ScmTag(scmTag));
             if(result.isSuccess()){
                 repositoryCloned = true;


### PR DESCRIPTION
As a result of a recent security change on github, the `git` protocol is no longer supported, resulting in such errors during the "brownout" on 2021-11-02.
```
[2021-11-02T13:55:14.439Z] Error : The git-clone command failed. || Cloning into '/jenkins/workspace/builders_URR-pr-builder_PR-5117/output-bouncycastle-api/work/bouncycastle-api'...
[2021-11-02T13:55:14.439Z] fatal: remote error: 
[2021-11-02T13:55:14.439Z]   The unauthenticated git protocol on port 9418 is no longer supported.
[2021-11-02T13:55:14.439Z] Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
[2021-11-02T13:55:14.439Z] 
[2021-11-02T13:55:14.439Z] Nov 02, 2021 1:55:14 PM org.jenkins.tools.test.PluginCompatTester testPlugins
[2021-11-02T13:55:14.439Z] SEVERE: Internal error while executing a test for core 2.277.5-cb-7 and plugin bouncycastle-api 2.20. Please submit a bug to plugin-compat-tester
[2021-11-02T13:55:14.440Z] org.jenkins.tools.test.exception.PluginSourcesUnavailableException: Problem while checking out plugin sources!
[2021-11-02T13:55:14.440Z] 	at org.jenkins.tools.test.PluginCompatTester.testPluginAgainst(PluginCompatTester.java:496)
[2021-11-02T13:55:14.440Z] 	at org.jenkins.tools.test.PluginCompatTester.testPlugins(PluginCompatTester.java:313)
[2021-11-02T13:55:14.440Z] 	at org.jenkins.tools.test.PluginCompatTesterCli.main(PluginCompatTesterCli.java:178)
[2021-11-02T13:55:14.440Z] Caused by: java.lang.RuntimeException: The git-clone command failed. || Cloning into '/jenkins/workspace/builders_URR-pr-builder_PR-5117/output-bouncycastle-api/work/bouncycastle-api'...
[2021-11-02T13:55:14.440Z] fatal: remote error: 
[2021-11-02T13:55:14.440Z]   The unauthenticated git protocol on port 9418 is no longer supported.
[2021-11-02T13:55:14.440Z] Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
